### PR TITLE
Add support for rootcontent extension (version 1)

### DIFF
--- a/src/system/modules/Avisota2/dca/tl_article.php
+++ b/src/system/modules/Avisota2/dca/tl_article.php
@@ -7,7 +7,7 @@
  * Extension for:
  * Contao Open Source CMS
  * Copyright (C) 2005-2012 Leo Feyer
- * 
+ *
  * Formerly known as TYPOlight Open Source CMS.
  *
  * This program is free software: you can redistribute it and/or
@@ -37,12 +37,12 @@ class tl_article_avisota extends tl_article
 {
 	public function alterDataContainer($strName)
 	{
-		if ($strName == 'tl_article')
+		if ($strName == 'tl_article' && !in_array('rootcontent', $this->Config->getActiveModules()))
 		{
 			$GLOBALS['TL_DCA']['tl_article']['list']['sorting']['paste_button_callback'][0] = 'tl_article_avisota';
 		}
 	}
-	
+
 	public function pasteArticle(DataContainer $dc, $row, $table, $cr, $arrClipboard=false)
 	{
 		if ($table == $GLOBALS['TL_DCA'][$dc->table]['config']['ptable'] && $row['type'] == 'avisota')


### PR DESCRIPTION
The rootcontent extension also needs to override the paste_button_callback of tl_article.

https://github.com/aschempp/contao-rootcontent/commit/becd42169c80437bcffe9d5e641244546a2fc123

Be aware that this applies to both Avisota 1 and 2!
