### PR TITLE
restored 2.11.10 compatibility

### DIFF
--- a/system/modules/Avisota/ModuleAvisotaRegistration.php
+++ b/system/modules/Avisota/ModuleAvisotaRegistration.php
@@ -36,9 +36,9 @@
 
 class ModuleAvisotaRegistration extends ModuleRegistration {
 	
-	protected function loadDataContainer($strTable)
+	protected function loadDataContainer($strTable,$blnNoCache=false)
 	{
-		parent::loadDataContainer($strTable);
+		parent::loadDataContainer($strTable,$blnNoCache);
 		
 		$this->import('AvisotaRegistrationDCA');
 		$this->AvisotaRegistrationDCA->setSelectableLists($this->avisota_registration_lists);


### PR DESCRIPTION
Hi Tristan,

please restore 2.11.10 compatibility for Avisota.
I did not check the whole source code, but I changed these two lines to avoid an error message due to incompatibility of ModuleAvistotaRegistration::loadDataContainer to ModuleRegistration::loadDataContainer.

Thanks.
